### PR TITLE
fix: callstack error

### DIFF
--- a/common/services/AuthService.ts
+++ b/common/services/AuthService.ts
@@ -26,10 +26,10 @@ class PersistentStore implements LokAPIType.IPersistentStore {
 }
 
 class NativeLokAPI extends LokAPIAbstract {
-    constructor(host: string, dbName: string, private apiService: AuthService) {
+    constructor(host: string, dbName: string, private httpRequestAuthService: AuthService) {
         super(host, dbName);
     }
-    httpRequest = async (opts: LokAPIType.coreHttpOpts) => this.apiService.lokAPIRequest(opts);
+    httpRequest = async (opts: LokAPIType.coreHttpOpts) => this.httpRequestAuthService(opts);
     base64Encode = base64Encode;
     persistentStore = new PersistentStore();
 }
@@ -310,8 +310,8 @@ export default class AuthService extends NetworkService {
     lokAPI: NativeLokAPI;
     constructor() {
         super();
-
-        this.lokAPI = new NativeLokAPI(APP_HOST, APP_DB, this);
+        var self = this;
+        this.lokAPI = new NativeLokAPI(APP_HOST, APP_DB, (opts) => self.lokAPIRequest(opts));
         this.lokAPI.apiToken = this.token;
     }
 


### PR DESCRIPTION
Was due to the fact that:
- nativescript collectionview implementation enforces a deep traverse of its items
- lokapi objects are self sufficient and carry refs to their libraries, but support vuejs proxy observation way to watch
- an external AuthService reference was added to lokapi object, and AuthService carry references to vuejs objects
- VueJS objects do not support vuejs deep traverse of its items

Signed-off-by: Valentin Lab <valentin.lab@kalysto.org>